### PR TITLE
Remove fields from test/IT classes that duplicate the @ActiveProfiles…

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -75,7 +75,7 @@ Behind the scenes, RMap uses [Spring Profiles](http://docs.spring.io/spring/docs
 
 The use of an in-memory profile is mutually exclusive with its analog.  For example, activating the `inmemory-triplestore` _and_ the `http-triplestore` at the same time is not supported.
 
-For production, the following profiles are active:
+For production (i.e. the RMap API and HTML UI web applications), the following profiles are active:
 * `persistent-db`
 * `ark-idservice`
 * `http-triplestore`
@@ -83,7 +83,7 @@ For production, the following profiles are active:
 * `prod-kafka`
 * `auto-start-indexing`
 
-For development, the following profiles are active:
+For development (i.e. when executing unit tests), the following profiles are active:
 * `inmemory-triplestore`
 * `inmemory-db`
 * `inmemory-idservice`
@@ -97,7 +97,9 @@ For integration tests, the following profiles are active:
 * `http-solr`
 * `prod-kafka`
 
-Regardless of which profiles are active, the `rmap.properties` file is used for configuration.  That means you can configure the database connectivity and the identifier generation service in the same place, regardless of which profiles are active.
+The `rmap.properties` configuration file is used for runtime configuration; most properties specified therein will override the default values.  
+
+By default, `rmap.properties` is discovered as the class path resource `/rmap.properties`.  A different resource can be specified by the system property `rmap.configFile`.  For example, `-Drmap.configFile=file:///path/to/rmap.conf` will configure RMap from a `file:/` URL pointing to `rmap.conf` instead of discovering `/rmap.properties` on the class path.  This can be useful when preserving RMap settings across application upgrades.
 
 ## Logging
 Logging for the runtime is configured in two places.  

--- a/api/src/test/java/info/rmapproject/api/ApiTestAbstractIT.java
+++ b/api/src/test/java/info/rmapproject/api/ApiTestAbstractIT.java
@@ -38,22 +38,5 @@ import org.springframework.transaction.annotation.Transactional;
 @ContextConfiguration("classpath:/beans.xml")
 @Transactional
 public abstract class ApiTestAbstractIT {
-	
-	private static final String SPRING_ACTIVE_PROFILE_PROP = "spring.profiles.active";
-	private static boolean activeProfilesPreSet = System.getProperties().containsKey(SPRING_ACTIVE_PROFILE_PROP);
-	
-	@BeforeClass
-	public static void setUpSpringProfiles() {
-		if (!activeProfilesPreSet) {
-			System.setProperty(SPRING_ACTIVE_PROFILE_PROP, "default,inmemory-db,inmemory-idservice,inmemory-triplestore,embedded-solr,mock-kafka");
-		}
-	}
-
-	@AfterClass
-	public static void resetSpringProfiles() throws Exception {
-		if (!activeProfilesPreSet) {
-			System.getProperties().remove(SPRING_ACTIVE_PROFILE_PROP);
-		}
-	}
 
 }

--- a/auth/src/test/java/info/rmapproject/auth/AuthDBAbstractIT.java
+++ b/auth/src/test/java/info/rmapproject/auth/AuthDBAbstractIT.java
@@ -38,22 +38,5 @@ import org.springframework.transaction.annotation.Transactional;
 @ContextConfiguration({ "classpath*:/spring-rmapauth-context.xml", "classpath*:/rmap-kafka-shared-test.xml" })
 @Transactional
 public abstract class AuthDBAbstractIT {
-
-	private static final String SPRING_ACTIVE_PROFILE_PROP = "spring.profiles.active";
-	private static boolean activeProfilesPreSet = System.getProperties().containsKey(SPRING_ACTIVE_PROFILE_PROP);
-
-	@BeforeClass
-	public static void setUpSpringProfiles() {
-		if (!activeProfilesPreSet) {
-			System.setProperty("spring.profiles.active", "default,inmemory-db,inmemory-idservice,inmemory-triplestore,mock-kafka");
-		}
-	}
-	
-	@AfterClass
-	public static void resetSpringProfiles() throws Exception {
-		if (!activeProfilesPreSet) {
-			System.getProperties().remove(SPRING_ACTIVE_PROFILE_PROP);
-		}
-	}
 	
 }

--- a/indexing-solr/src/test/java/info/rmapproject/indexing/solr/AbstractSpringIndexingTest.java
+++ b/indexing-solr/src/test/java/info/rmapproject/indexing/solr/AbstractSpringIndexingTest.java
@@ -25,20 +25,4 @@ public abstract class AbstractSpringIndexingTest {
     @Autowired
     protected RDFHandler rdfHandler;
 
-    protected static boolean thisClassSetProfilesProperty = false;
-
-    @Before
-    public void setUp() throws Exception {
-        if (System.getProperty("spring.profiles.active") == null) {
-            System.setProperty("spring.profiles.active", "default, inmemory-db, inmemory-triplestore, inmemory-idservice, embedded-solr, mock-kafka");
-            thisClassSetProfilesProperty = true;
-        }
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        if (thisClassSetProfilesProperty) {
-            System.getProperties().remove("spring.profiles.active");
-        }
-    }
 }

--- a/indexing-solr/src/test/java/info/rmapproject/indexing/solr/repository/IndexDTOTest.java
+++ b/indexing-solr/src/test/java/info/rmapproject/indexing/solr/repository/IndexDTOTest.java
@@ -22,11 +22,8 @@ public class IndexDTOTest extends AbstractSpringIndexingTest {
 
     private static TestResourceManager rm;
 
-    @Override
     @Before
     public void setUp() throws Exception {
-        super.setUp();
-
         rm = TestResourceManager.load("/data/discos/rmd18mddcw", RDFFormat.NQUADS, rdfHandler);
     }
 

--- a/indexing-solr/src/test/java/info/rmapproject/indexing/solr/repository/StandAloneStatusInferencerTest.java
+++ b/indexing-solr/src/test/java/info/rmapproject/indexing/solr/repository/StandAloneStatusInferencerTest.java
@@ -28,8 +28,6 @@ public class StandAloneStatusInferencerTest extends AbstractSpringIndexingTest {
 
     @Before
     public void setUp() throws Exception {
-        super.setUp();
-
         rm = TestResourceManager.load(
                 "/data/discos/rmd18mddcw", RDFFormat.NQUADS, rdfHandler);
     }

--- a/webapp/src/test/java/info/rmapproject/webapp/WebTestAbstractIT.java
+++ b/webapp/src/test/java/info/rmapproject/webapp/WebTestAbstractIT.java
@@ -40,22 +40,4 @@ import org.springframework.test.context.web.WebAppConfiguration;
 @ContextConfiguration({"classpath*:/servlet-context.xml", "classpath*:/rmap-kafka-shared-test.xml"})
 public abstract class WebTestAbstractIT {
 
-	private static final String SPRING_ACTIVE_PROFILE_PROP = "spring.profiles.active";
-	protected static boolean thisClassSetProfilesProperty = false;
-
-	@Before
-    public void setUp() throws Exception {
-        if (System.getProperty(SPRING_ACTIVE_PROFILE_PROP) == null) {
-            System.setProperty(SPRING_ACTIVE_PROFILE_PROP, "default, inmemory-db, inmemory-triplestore, inmemory-idservice, embedded-solr, mock-kafka");
-            thisClassSetProfilesProperty = true;
-        }
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        if (thisClassSetProfilesProperty) {
-            System.getProperties().remove(SPRING_ACTIVE_PROFILE_PROP);
-        }
-    }
-	
 }


### PR DESCRIPTION
… annotation.  Maintaining the synchronicity between @ActiveProfiles and these fields may not be worth the cost.